### PR TITLE
Module2 improve eloi

### DIFF
--- a/germinette/core.py
+++ b/germinette/core.py
@@ -255,9 +255,7 @@ class BaseTester:
             missing = []
             
             for node in ast.walk(tree):
-                # Check functions and methods (but skip __init__ if it only has self)
                 if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                    # Skip private methods that start with __ (except __init__)
                     if node.name.startswith("__") and node.name != "__init__":
                         continue
                     

--- a/germinette/subjects/python_module_02.py
+++ b/germinette/subjects/python_module_02.py
@@ -119,7 +119,7 @@ class Tester(BaseTester):
                  self.record_error(exercise_label, "Style Error (Missing Docstrings)", doc_errors)
                  return None, None
             
-            # Check Type Hints (Module 02 Strictness)
+            # Check Type Hints (Mandatory in module 2)
             type_hint_errors = self.check_type_hints(found_path)
             if type_hint_errors:
                  console.print("[red]KO[/red]")

--- a/germinette/subjects/python_module_03.py
+++ b/germinette/subjects/python_module_03.py
@@ -85,7 +85,6 @@ class Tester(BaseTester):
              self.record_error(exercise_label, "Style Error (Missing Docstrings)", doc_errors)
              return None, None
         
-        # Type Hints
         type_hint_errors = self.check_type_hints(found_path)
         if type_hint_errors:
              console.print("[red]KO[/red]")


### PR DESCRIPTION
This pull request introduces mandatory type hint checks for Python module exercises 2 and 3. A new method is added to verify that all functions and methods in a submitted file include type annotations for both parameters and return types. If any are missing, the module will not load and an error will be recorded.

Type hint enforcement:

* Added a `check_type_hints` method in `germinette/core.py` to ensure all functions and methods have type annotations for parameters (excluding `self` and `cls`) and return values. The method reports missing annotations with line numbers.

Integration with module loading:

* Updated the `_load_module` method in `germinette/subjects/python_module_02.py` to call `check_type_hints` and reject modules with missing type hints, recording a "Style Error (Missing Type Hints)" if any are found.
* Updated the `_load_module` method in `germinette/subjects/python_module_03.py` to similarly enforce type hint checks and error recording.